### PR TITLE
feat: Add a way for Cast classes to express when an attribute should be unset (removed)

### DIFF
--- a/app/Casts/CastFloatOrUnset.php
+++ b/app/Casts/CastFloatOrUnset.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Carsdotcom\LaravelJsonModel\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+
+class CastFloatOrUnset implements ShouldUnset, CastsInboundAttributes
+{
+    public static function shouldUnset(mixed $value): bool
+    {
+        return ($value === null);
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($this->shouldUnset($value)) {
+            return null;
+        }
+        return (float)$value;
+    }
+}

--- a/app/Casts/CastNonEmptyStringOrUnset.php
+++ b/app/Casts/CastNonEmptyStringOrUnset.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Carsdotcom\LaravelJsonModel\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+
+class CastNonEmptyStringOrUnset implements ShouldUnset, CastsInboundAttributes
+{
+    public static function shouldUnset(mixed $value): bool
+    {
+        return ($value === null || $value === '');
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($this->shouldUnset($value)) {
+            return null;
+        }
+        return (string)$value;
+    }
+}

--- a/app/Casts/CastStringOrUnset.php
+++ b/app/Casts/CastStringOrUnset.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Carsdotcom\LaravelJsonModel\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+
+class CastStringOrUnset implements ShouldUnset, CastsInboundAttributes
+{
+    public static function shouldUnset(mixed $value): bool
+    {
+        return ($value === null);
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($this->shouldUnset($value)) {
+            return null;
+        }
+        return (string)$value;
+    }
+}

--- a/app/Casts/ShouldUnset.php
+++ b/app/Casts/ShouldUnset.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Carsdotcom\LaravelJsonModel\Casts;
+
+interface ShouldUnset
+{
+    static function shouldUnset(mixed $value): bool;
+}

--- a/app/JsonModel.php
+++ b/app/JsonModel.php
@@ -21,6 +21,7 @@ use ArrayAccess;
 use Carsdotcom\JsonSchemaValidation\Exceptions\JsonSchemaValidationException;
 use Carsdotcom\JsonSchemaValidation\Helpers\FriendlyClassName;
 use Carsdotcom\JsonSchemaValidation\Traits\ValidatesWithJsonSchema;
+use Carsdotcom\LaravelJsonModel\Casts\ShouldUnset;
 use Carsdotcom\LaravelJsonModel\Contracts\CanCascadeEvents;
 use Carsdotcom\JsonSchemaValidation\Contracts\CanValidate;
 use Carsdotcom\LaravelJsonModel\Helpers\ClassUsesTrait;
@@ -692,5 +693,25 @@ abstract class JsonModel implements ArrayAccess, Jsonable, JsonSerializable, Can
     public static function preventsAccessingMissingAttributes()
     {
         return static::$modelsShouldPreventAccessingMissingAttributes;
+    }
+
+    /**
+     * Extends setAttribute to cooperate with casts that implement ShouldUnset.
+     * If the cast wishes, we'll *remove* the attribute from the Json representation.
+     * This lets us implement things like PATCH {"zip":null} to mean "remove ZIP, return to default behavior"
+     */
+    use HasAttributes {
+        setAttribute as protected eloquentSetAttribute;
+    }
+
+    public function setAttribute($key, $value) {
+        $castType = $this->hasCast($key) ? $this->getCastType($key) : null;
+        if (is_a($castType, ShouldUnset::class, true) && $castType::shouldUnset($value)) {
+                unset($this->attributes[$key]);
+                return $this;
+        }
+
+        $this->eloquentSetAttribute($key, $value);
+        return $this;
     }
 }

--- a/tests/Unit/JsonModelTest.php
+++ b/tests/Unit/JsonModelTest.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Carsdotcom\JsonSchemaValidation\Exceptions\JsonSchemaValidationException;
+use Carsdotcom\LaravelJsonModel\Casts\CastFloatOrUnset;
+use Carsdotcom\LaravelJsonModel\Casts\CastNonEmptyStringOrUnset;
+use Carsdotcom\LaravelJsonModel\Casts\CastStringOrUnset;
 use Carsdotcom\LaravelJsonModel\CollectionOfJsonModels;
 use Carsdotcom\JsonSchemaValidation\SchemaValidator as SchemaValidator;
 use Carsdotcom\LaravelJsonModel\JsonModel;
@@ -902,6 +905,79 @@ class JsonModelTest extends BaseTestCase
             "The properties must match schema: shirt\nThe data should match one item from enum",
             "Sorry, Starbuck is not a valid choice for Best Star Trek Captain."
         ], array_map(fn ($e) => ($e instanceof JsonSchemaValidationException) ? $e->errorsAsMultilineString() : $e->getMessage(), $caughtExceptions));
+    }
+
+    public function testCastFloatOrUnset(): void
+    {
+        $jsonModel = new class extends JsonModel{
+            protected $casts = [
+                'fou' => CastFloatOrUnset::class
+            ];
+        };
+
+        self::assertFalse(isset($jsonModel->fou), "Initializes unset");
+        $jsonModel->fou = null;
+        self::assertFalse(isset($jsonModel->fou), "Stays unset on initialize to null");
+        $jsonModel->fou = 6.9;
+        self::assertSame(6.9, $jsonModel->fou, "Float is unchanged");
+        $jsonModel->fou = '6';
+        self::assertSame(6.0, $jsonModel->fou, "String is cast");
+        $jsonModel->fou = 9;
+        self::assertSame(9.0, $jsonModel->fou, "int is cast");
+        self::assertStringContainsString('"fou":9', $jsonModel->toJson());
+        $jsonModel->fou = null;
+        self::assertFalse(isset($jsonModel->fou), "Set to null unsets attribute");
+        self::assertStringNotContainsString('fou', $jsonModel->toJson());
+    }
+
+    public function testCastStringOrUnset(): void
+    {
+        $jsonModel = new class extends JsonModel{
+            protected $casts = [
+                'sou' => CastStringOrUnset::class
+            ];
+        };
+
+        self::assertFalse(isset($jsonModel->sou), "Initializes unset");
+        $jsonModel->sou = null;
+        self::assertFalse(isset($jsonModel->sou), "Stays unset on initialize to null");
+        $jsonModel->sou = 'happy happy';
+        self::assertSame('happy happy', $jsonModel->sou, "String is unchanged");
+        $jsonModel->sou = 6;
+        self::assertSame('6', $jsonModel->sou, "int is cast");
+        $jsonModel->sou = false;
+        self::assertSame('', $jsonModel->sou, "bool is cast");
+        self::assertStringContainsString('"sou":""', $jsonModel->toJson());
+        $jsonModel->sou = null;
+        self::assertFalse(isset($jsonModel->sou), "Set to null unsets attribute");
+        self::assertStringNotContainsString('sou', $jsonModel->toJson());
+    }
+
+    public function testCastNonEmptyStringOrUnset(): void
+    {
+        $jsonModel = new class extends JsonModel{
+            protected $casts = [
+                'sou' => CastNonEmptyStringOrUnset::class
+            ];
+        };
+
+        self::assertFalse(isset($jsonModel->sou), "Initializes unset");
+        $jsonModel->sou = null;
+        self::assertFalse(isset($jsonModel->sou), "Stays unset on initialize to null");
+        $jsonModel->sou = 'happy happy';
+        self::assertSame('happy happy', $jsonModel->sou, "String is unchanged");
+
+        $jsonModel->sou = '';
+        self::assertFalse(isset($jsonModel->sou), "Set to empty string unsets attribute");
+        self::assertStringNotContainsString('sou', $jsonModel->toJson());
+
+        $jsonModel->sou = 6;
+        self::assertSame('6', $jsonModel->sou, "int is cast");
+        self::assertStringContainsString('"sou":"6"', $jsonModel->toJson());
+
+        $jsonModel->sou = null;
+        self::assertFalse(isset($jsonModel->sou), "Set to null unsets attribute");
+        self::assertStringNotContainsString('sou', $jsonModel->toJson());
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/carsdotcom/laravel-json-model/issues/5

The `\Carsdotcom\LaravelJsonModel\Casts\ShouldUnset` also gives other projects a way to implement a custom cast that unsets (like Online Shopper's person.zip **also** needs a formatter)