### PR TITLE
fix: JsonModels in CollectionOfJsonModel should not be ->isDirty after ->fresh

### DIFF
--- a/app/CollectionOfJsonModels.php
+++ b/app/CollectionOfJsonModels.php
@@ -73,7 +73,10 @@ class CollectionOfJsonModels extends Collection implements CanValidate
      */
     public function fresh(): self
     {
-        return $this->fill($this->getLinkedData() ?: []);
+        return $this
+            ->fill($this->getLinkedData() ?: [])
+            // We loaded them from linked data, they are not dirty
+            ->each(fn ($model) => $model->syncOriginal());
     }
 
     /**

--- a/tests/Unit/CollectionOfJsonModelsTest.php
+++ b/tests/Unit/CollectionOfJsonModelsTest.php
@@ -378,6 +378,7 @@ class CollectionOfJsonModelsTest extends BaseTestCase
             ->fresh();
         self::assertCount(1, $collection);
         self::assertTrue($collection[0]->exists);
+        self::assertFalse($collection[0]->isDirty());
     }
 
     public function testSaveCollectionSkipsCreatingListenerForExistingChildren()

--- a/tests/Unit/Traits/HasJsonModelAttributesTest.php
+++ b/tests/Unit/Traits/HasJsonModelAttributesTest.php
@@ -33,6 +33,7 @@ class HasJsonModelAttributesTest extends BaseTestCase
         };
         self::assertInstanceOf(ConcreteJsonModel::class, $model->jsonModel);
         self::assertSame(1, $model->jsonModel->a);
+        self::assertFalse($model->jsonModel->isDirty(), "Loaded attributes are not dirty");
     }
 
     public function testWholeAttributeMissingIsEmptyObject()
@@ -406,6 +407,7 @@ class HasJsonModelAttributesTest extends BaseTestCase
         self::assertCount(1, $model->jsons);
         self::assertInstanceOf(ConcreteJsonModel::class, $model->jsons->first());
         self::assertSame(1, $model->jsons->first()->id);
+        self::assertFalse($model->jsons->first()->isDirty(), "Loaded models in a collection-attribute are not dirty");
     }
 
     public function testAttributeCanBeTestedWithIsset()


### PR DESCRIPTION
When a CollectionOfJsonModel loads models via `->fresh()` we know they are in a pristine original state, they should not be `isDirty`.

This benefits HasJsonModelAttributes (that's where the bug was identified), but it works anywhere you ->fresh a collection.

Resolves issue #11 