### PR TITLE
feat: PHP 8.4 Support

### DIFF
--- a/app/CollectionOfJsonModels.php
+++ b/app/CollectionOfJsonModels.php
@@ -47,7 +47,7 @@ class CollectionOfJsonModels extends Collection implements CanValidate
      * @param string $itemClass
      * @return CollectionOfJsonModels
      */
-    public function setType(string $itemClass = null): self
+    public function setType(?string $itemClass = null): self
     {
         if (!is_a($itemClass, JsonModel::class, true)) {
             throw new \DomainException('CollectionOfJsonModels type must be a descendent of JsonModel');
@@ -61,7 +61,7 @@ class CollectionOfJsonModels extends Collection implements CanValidate
      * @param string|null $key
      * @return CollectionOfJsonModels
      */
-    public function setPrimaryKey(string $key = null): self
+    public function setPrimaryKey(?string $key = null): self
     {
         $this->primaryKey = $key;
         return $this;
@@ -202,7 +202,7 @@ class CollectionOfJsonModels extends Collection implements CanValidate
      * @throws JsonSchemaValidationException   if data is invalid
      */
     public function validateOrThrow(
-        string $exceptionMessage = null,
+        ?string $exceptionMessage = null,
         int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
     ): bool {
         if (!$this->itemClass) {

--- a/app/JsonModel.php
+++ b/app/JsonModel.php
@@ -458,7 +458,7 @@ abstract class JsonModel implements ArrayAccess, Jsonable, JsonSerializable, Can
      * so if you have validation states where two attributes have to agree, choose `update` instead.
      * @return bool was save successful?
      */
-    public function safeUpdateRecursive(array $attributes, bool $isRootOfChange = true, array &$caughtExceptions = null): bool
+    public function safeUpdateRecursive(array $attributes, bool $isRootOfChange = true, ?array &$caughtExceptions = null): bool
     {
         if ($caughtExceptions === null) {
             $caughtExceptions = [];


### PR DESCRIPTION
- Update method signatures to accept nullables for better type safety and clarity.
- In CollectionOfJsonModels: setType, setPrimaryKey and validateOrThrow now use ?string for nullable string parameters.
- In JsonModel: safeUpdateRecursive now accepts ?array for the passed-by-reference caughtExceptions parameter.

These changes preserve default null behavior while making nullability explicit for static analysis and tooling.