### PR TITLE
feat: add PHPStan extension suppressing HasEvents class.missingExtends

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,13 @@
         "preferred-install": "dist",
         "sort-packages": true
     },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,9 @@
+parameters:
+    ignoreErrors:
+        # JsonModel intentionally uses HasEvents without extending Eloquent\Model.
+        # HasEvents requires Model only for its dispatcher infrastructure, which JsonModel
+        # provides directly (static $dispatcher, bootIfNotBooted, etc.).
+        -
+            message: '#Trait Illuminate\\Database\\Eloquent\\Concerns\\HasEvents requires using class to extend Illuminate\\Database\\Eloquent\\Model#'
+            identifier: class.missingExtends
+            reportUnmatched: false


### PR DESCRIPTION
## Summary

- Ships `extension.neon` that suppresses the `class.missingExtends` error caused by `JsonModel` using `HasEvents` without extending `Eloquent\Model`
- Exposes the extension via `extra.phpstan.includes` in `composer.json` so PHPStan auto-discovers it when the package is installed
- Consumers no longer need their own `ignoreErrors` rule for this — the fix lives here where it belongs

## Background

`HasEvents` carries a `@phpstan-require-extends Model` annotation. `JsonModel` intentionally does not extend `Model` but does provide all the dispatcher infrastructure `HasEvents` needs (`static $dispatcher`, `bootIfNotBooted`, etc.). This is a known, intentional design — the `HasRelationships` equivalent was resolved in v1.4.3 by replacing the trait with stubs; `HasEvents` cannot be removed so a PHPStan extension is the right fix.

## Test plan

- [x] Install the package in a consumer project (e.g. `services/incentives`) and confirm `phpstan` passes without a local `class.missingExtends` ignore
- [x] Confirm `reportUnmatched: false` means no warning if a future Laravel version changes the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)