### PR TITLE
feat: permit laravel-json-schema ^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "carsdotcom/laravel-json-schema": "^v1.0.1 || ^v2 || ^2.1",
+        "carsdotcom/laravel-json-schema": "^v1.0.1 || ^v2 || ^2.1 || ^3",
         "ext-json": "*",
         "php": "^8.1",
         "laravel/framework": "^9.19 || ^10.0 || ^11.0 || ^12.0"


### PR DESCRIPTION
## Summary
- Expands the `carsdotcom/laravel-json-schema` version constraint to also allow `^3`

## Test plan
- [x] Full CI test matrix passes across PHP and Laravel versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)