### PR TITLE
fix: add @template/@extends generics to CollectionOfJsonModels

### DIFF
--- a/app/CollectionOfJsonModels.php
+++ b/app/CollectionOfJsonModels.php
@@ -20,8 +20,10 @@ use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Class CollectionOfJsonModels
- * @package Carsdotcom\LaravelJsonModel
+ * @template TKey of array-key
+ * @template TValue of JsonModel
+ * @extends Collection<TKey, TValue>
+ * @implements ArrayAccess<TKey, TValue>
  */
 class CollectionOfJsonModels extends Collection implements CanValidate
 {


### PR DESCRIPTION
Fixes #24.

## Summary

- Adds `@template TKey of array-key` and `@template TValue of JsonModel` to `CollectionOfJsonModels`
- Adds `@extends Collection<TKey, TValue>` and `@implements ArrayAccess<TKey, TValue>` to bind the type parameters through to Laravel's generic `Collection`
- Removes redundant `Class X` and `@package` lines from the same docblock

## Why

PHPDoc generics don't propagate automatically through `extends` — each class must re-declare or bind the parameters. Without these annotations, `TValue` is silently erased at the `CollectionOfJsonModels` boundary, so `first()`, `last()`, `map()`, etc. lose their element type in PhpStorm and Psalm/PHPStan.

## Notes

- Doc-only change — zero runtime behaviour impact
- All 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)